### PR TITLE
feature/roshan/signup: enforcing terms & agreement on signup

### DIFF
--- a/app/route.py
+++ b/app/route.py
@@ -51,6 +51,11 @@ def signup_page():
         last_name = request.form.get('last_name', '').strip()
         email = request.form.get('email', '').strip().lower()
         password = request.form.get('password', '')
+        terms_accepted = request.form.get('terms_accepted') == 'on'
+
+        if not terms_accepted:
+            flash('Please agree to the Terms of Service and Privacy Policy before signing up.', 'error')
+            return render_template('signuppage.html')
 
         new_user, error = AuthService.signup_user(first_name, last_name, email, password)
         if error:

--- a/app/seed.py
+++ b/app/seed.py
@@ -1,5 +1,7 @@
 import argparse
 
+from werkzeug.security import generate_password_hash
+
 from app import app
 from app.extensions import db
 from app.models import Category, Message, Product, ProductImage, User
@@ -38,28 +40,6 @@ def seed_database(force_reset: bool = False) -> None:
             ("Hannah", "Yeo", "hannah@example.com", "password123", "normal"),
             ("Ivan", "Koh", "ivan@example.com", "password123", "normal"),
             ("Jasmine", "Teo", "jasmine@example.com", "password123", "normal"),
-        users = [
-            User(
-                first_name="Alice",
-                last_name="Nguyen",
-                email="alice@example.com",
-                password="password123",
-                role="normal",
-            ),
-            User(
-                first_name="Ben",
-                last_name="Lee",
-                email="ben@example.com",
-                password="password123",
-                role="normal",
-            ),
-            User(
-                first_name="Carol",
-                last_name="Tan",
-                email="carol@example.com",
-                password="password123",
-                role="admin",
-            ),
         ]
 
         users = []
@@ -70,7 +50,7 @@ def seed_database(force_reset: bool = False) -> None:
                     first_name=first_name,
                     last_name=last_name,
                     email=email,
-                    password=_to_base64(raw_password),
+                    password=generate_password_hash(raw_password),
                     role=role,
                 )
                 db.session.add(user)
@@ -88,10 +68,6 @@ def seed_database(force_reset: bool = False) -> None:
             "Automotive",
             "Garden",
             "Gaming",
-        categories = [
-            Category(category_name="Electronics"),
-            Category(category_name="Books"),
-            Category(category_name="Home"),
         ]
 
         categories = []

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -13,3 +13,83 @@ document.addEventListener("DOMContentLoaded", () => {
     }, 500);
   }, 5000);
 });
+
+document.addEventListener("DOMContentLoaded", () => {
+  const termsCheckbox = document.getElementById("terms-accepted-checkbox");
+  const signupButton = document.getElementById("signup-submit-btn");
+  const legalOverlay = document.getElementById("legal-modal-overlay");
+  const legalTitle = document.getElementById("legal-modal-title");
+  const legalContent = document.getElementById("legal-modal-content");
+  const legalClose = document.getElementById("legal-modal-close");
+  const legalTriggers = document.querySelectorAll("[data-legal-trigger]");
+
+  if (!termsCheckbox || !signupButton) return;
+
+  const LEGAL_COPY = {
+    terms: {
+      title: "Terms of Service",
+      body: `
+        <p>SwanFlip is for UWA community members only. By creating an account, you agree to use the marketplace honestly and respectfully.</p>
+        <p>You must provide accurate listing details, including real item condition, clear pricing, and truthful descriptions.</p>
+        <p>Transactions should be arranged safely in public places. Users are responsible for verifying items before payment.</p>
+        <p>Illegal products, prohibited goods, scams, and abusive behavior are not allowed and may result in account suspension.</p>
+      `,
+    },
+    privacy: {
+      title: "Privacy Policy",
+      body: `
+        <p>We collect basic profile information (name, email) to create and secure your account.</p>
+        <p>Your data is used to provide login/session functionality, listing management, and user-to-user communication features.</p>
+        <p>We do not request unnecessary personal data for marketplace use.</p>
+        <p>By continuing, you acknowledge that your account activity may be used to maintain platform safety and service quality.</p>
+      `,
+    },
+  };
+
+  const updateSignupButtonState = () => {
+    const enabled = termsCheckbox.checked;
+    signupButton.disabled = !enabled;
+    signupButton.classList.toggle("opacity-50", !enabled);
+    signupButton.classList.toggle("cursor-not-allowed", !enabled);
+    signupButton.classList.toggle("hover:scale-105", enabled);
+    signupButton.classList.toggle("hover:bg-blue-900", enabled);
+  };
+
+  const closeLegalModal = () => {
+    if (!legalOverlay) return;
+    legalOverlay.classList.add("hidden");
+    legalOverlay.classList.remove("flex");
+  };
+
+  const openLegalModal = (kind) => {
+    if (!legalOverlay || !legalTitle || !legalContent) return;
+    const selected = LEGAL_COPY[kind] || LEGAL_COPY.terms;
+    legalTitle.textContent = selected.title;
+    legalContent.innerHTML = selected.body;
+    legalOverlay.classList.remove("hidden");
+    legalOverlay.classList.add("flex");
+  };
+
+  termsCheckbox.addEventListener("change", updateSignupButtonState);
+  updateSignupButtonState();
+
+  legalTriggers.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      openLegalModal(btn.dataset.legalTrigger);
+    });
+  });
+
+  if (legalClose) {
+    legalClose.addEventListener("click", closeLegalModal);
+  }
+
+  if (legalOverlay) {
+    legalOverlay.addEventListener("click", (event) => {
+      if (event.target === legalOverlay) closeLegalModal();
+    });
+  }
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") closeLegalModal();
+  });
+});

--- a/templates/signuppage.html
+++ b/templates/signuppage.html
@@ -61,6 +61,35 @@ block content %}
         required
       />
 
+      <div class="w-full max-w-sm rounded-lg border border-slate-300 bg-slate-50 p-3">
+        <div class="flex items-start gap-3">
+          <input
+            id="terms-accepted-checkbox"
+            type="checkbox"
+            name="terms_accepted"
+            class="mt-1 h-4 w-4 rounded border-gray-400 text-blue-800 focus:ring-blue-700"
+          />
+          <label for="terms-accepted-checkbox" class="text-sm leading-6 text-slate-700">
+            I agree to the
+            <button
+              type="button"
+              data-legal-trigger="terms"
+              class="font-semibold text-blue-800 underline hover:text-blue-900"
+            >
+              Terms of Service
+            </button>
+            and
+            <button
+              type="button"
+              data-legal-trigger="privacy"
+              class="font-semibold text-blue-800 underline hover:text-blue-900"
+            >
+              Privacy Policy
+            </button>.
+          </label>
+        </div>
+      </div>
+
       <p class="text-sm text-black">
         Already have an account?
         <a
@@ -73,11 +102,46 @@ block content %}
 
       <button
         type="submit"
+        id="signup-submit-btn"
+        disabled
         class="w-fit rounded-lg bg-[#3D3A9E] px-10 py-3 font-medium text-white transition-all hover:scale-105 hover:bg-blue-900"
       >
         Sign up
       </button>
     </form>
+  </div>
+</div>
+
+<div
+  id="legal-modal-overlay"
+  class="fixed inset-0 z-50 hidden items-center justify-center bg-black/40 px-4"
+>
+  <div class="w-full max-w-2xl rounded-xl bg-white p-6 shadow-2xl">
+    <div class="mb-4 flex items-start justify-between gap-4">
+      <h2 id="legal-modal-title" class="text-2xl font-bold text-slate-800">Terms of Service</h2>
+      <button
+        type="button"
+        id="legal-modal-close"
+        class="rounded-md px-2 py-1 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+        aria-label="Close legal modal"
+      >
+        X
+      </button>
+    </div>
+    <div id="legal-modal-content" class="max-h-[60vh] space-y-4 overflow-y-auto pr-1 text-sm leading-6 text-slate-700">
+      <p>
+        SwanFlip is a student marketplace for the UWA community. By using this platform, you agree to list items honestly and communicate respectfully.
+      </p>
+      <p>
+        Buyers and sellers are responsible for arranging safe meetups, checking item condition, and following Australian law and UWA policies.
+      </p>
+      <p>
+        Prohibited listings include illegal goods, dangerous items, and misleading or fraudulent posts.
+      </p>
+      <p>
+        Your account information is used to provide core marketplace features, account security, and transaction-related communication.
+      </p>
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Added Terms/Privacy agreement UI with modal content and disabled Sign Up button until consent is checked.

<img width="847" height="391" alt="image" src="https://github.com/user-attachments/assets/46855266-1528-4c46-a109-1d996f0b8436" />

---

<img width="835" height="340" alt="image" src="https://github.com/user-attachments/assets/171dc1ca-487d-43d4-815b-f848a50da17d" />

---

<img width="917" height="402" alt="image" src="https://github.com/user-attachments/assets/d6212626-9db4-4c70-8a3e-effe6a6ec9bc" />

---

<img width="648" height="301" alt="image" src="https://github.com/user-attachments/assets/3b065fcb-c59b-455d-b771-69ec0f8a57cc" />


closes #87 