### PR TITLE
Feature/roshan/signup terms agreement

### DIFF
--- a/app/route.py
+++ b/app/route.py
@@ -51,6 +51,11 @@ def signup_page():
         last_name = request.form.get('last_name', '').strip()
         email = request.form.get('email', '').strip().lower()
         password = request.form.get('password', '')
+        terms_accepted = request.form.get('terms_accepted') == 'on'
+
+        if not terms_accepted:
+            flash('Please agree to the Terms of Service and Privacy Policy before signing up.', 'error')
+            return render_template('signuppage.html')
 
         new_user, error = AuthService.signup_user(first_name, last_name, email, password)
         if error:

--- a/app/seed.py
+++ b/app/seed.py
@@ -1,5 +1,7 @@
 import argparse
 
+from werkzeug.security import generate_password_hash
+
 from app import app
 from app.extensions import db
 from app.models import Category, Message, Product, ProductImage, User
@@ -38,28 +40,6 @@ def seed_database(force_reset: bool = False) -> None:
             ("Hannah", "Yeo", "hannah@example.com", "password123", "normal"),
             ("Ivan", "Koh", "ivan@example.com", "password123", "normal"),
             ("Jasmine", "Teo", "jasmine@example.com", "password123", "normal"),
-        users = [
-            User(
-                first_name="Alice",
-                last_name="Nguyen",
-                email="alice@example.com",
-                password="password123",
-                role="normal",
-            ),
-            User(
-                first_name="Ben",
-                last_name="Lee",
-                email="ben@example.com",
-                password="password123",
-                role="normal",
-            ),
-            User(
-                first_name="Carol",
-                last_name="Tan",
-                email="carol@example.com",
-                password="password123",
-                role="admin",
-            ),
         ]
 
         users = []
@@ -70,7 +50,7 @@ def seed_database(force_reset: bool = False) -> None:
                     first_name=first_name,
                     last_name=last_name,
                     email=email,
-                    password=_to_base64(raw_password),
+                    password=generate_password_hash(raw_password),
                     role=role,
                 )
                 db.session.add(user)
@@ -88,10 +68,6 @@ def seed_database(force_reset: bool = False) -> None:
             "Automotive",
             "Garden",
             "Gaming",
-        categories = [
-            Category(category_name="Electronics"),
-            Category(category_name="Books"),
-            Category(category_name="Home"),
         ]
 
         categories = []

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -29,19 +29,41 @@ document.addEventListener("DOMContentLoaded", () => {
     terms: {
       title: "Terms of Service",
       body: `
-        <p>SwanFlip is for UWA community members only. By creating an account, you agree to use the marketplace honestly and respectfully.</p>
-        <p>You must provide accurate listing details, including real item condition, clear pricing, and truthful descriptions.</p>
-        <p>Transactions should be arranged safely in public places. Users are responsible for verifying items before payment.</p>
-        <p>Illegal products, prohibited goods, scams, and abusive behavior are not allowed and may result in account suspension.</p>
+        <div class="rounded-lg border border-slate-200 bg-slate-50 p-4">
+          <p class="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-semibold text-blue-700">Effective date: 1 January 2026</p>
+          <h3 class="mt-3 text-lg font-semibold text-slate-800">1. Account Use and Eligibility</h3>
+          <p>SwanFlip is a student marketplace intended for the UWA community, and by creating an account you agree to use the platform honestly, respectfully, and in good faith.</p>
+          <h3 class="mt-4 text-lg font-semibold text-slate-800">2. Listing Accuracy and Conduct</h3>
+          <p class="mt-3">You are responsible for ensuring that listings are accurate, including item condition, photos, availability, and pricing, and you must not post misleading, deceptive, or fraudulent content.</p>
+          <h3 class="mt-4 text-lg font-semibold text-slate-800">3. Buyer and Seller Responsibilities</h3>
+          <p class="mt-3">Buyers and sellers are responsible for communicating clearly, arranging safe public meetups where possible, and verifying items before completing transactions.</p>
+          <h3 class="mt-4 text-lg font-semibold text-slate-800">4. Risk, Safety and Enforcement</h3>
+          <p class="mt-3">SwanFlip does not guarantee product quality, seller reliability, or delivery outcomes, so users should apply reasonable caution when trading.</p>
+          <p class="mt-3">Prohibited activity includes illegal or unsafe goods, impersonation, harassment, spam, payment scams, or conduct that violates Australian law or UWA policies.</p>
+          <p class="mt-3">We may remove listings, restrict account access, or suspend users who breach rules or create safety risks. By continuing, you acknowledge marketplace interactions are user-to-user transactions and agree to moderation and safety processes that help maintain a trusted campus marketplace.</p>
+          <h3 class="mt-4 text-lg font-semibold text-slate-800">5. Policy Updates</h3>
+          <p class="mt-3">If terms are updated, the latest version will be shown at signup, and continued use of your account indicates acceptance of revisions unless additional consent is required by law.</p>
+        </div>
       `,
     },
     privacy: {
       title: "Privacy Policy",
       body: `
-        <p>We collect basic profile information (name, email) to create and secure your account.</p>
-        <p>Your data is used to provide login/session functionality, listing management, and user-to-user communication features.</p>
-        <p>We do not request unnecessary personal data for marketplace use.</p>
-        <p>By continuing, you acknowledge that your account activity may be used to maintain platform safety and service quality.</p>
+        <div class="rounded-lg border border-slate-200 bg-slate-50 p-4">
+          <p class="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-semibold text-blue-700">Effective date: 1 January 2026</p>
+          <h3 class="mt-3 text-lg font-semibold text-slate-800">1. Information We Collect</h3>
+          <p>SwanFlip collects and uses personal information only as needed to provide a safe and functional marketplace experience for the UWA community.</p>
+          <h3 class="mt-4 text-lg font-semibold text-slate-800">2. How We Use Information</h3>
+          <p class="mt-3">When you register, we collect account details such as your name, email address, and encrypted password to authenticate users, secure accounts, and support core features like listing management and user communication.</p>
+          <p class="mt-3">We may also process marketplace activity data, such as listing updates and in-platform interactions, to detect abuse, reduce fraud, and improve platform safety and reliability.</p>
+          <h3 class="mt-4 text-lg font-semibold text-slate-800">3. Data Minimization and Safety</h3>
+          <p class="mt-3">We do not intentionally request unnecessary sensitive personal information for normal use of the service, and we expect users not to publish private information in listings or messages.</p>
+          <h3 class="mt-4 text-lg font-semibold text-slate-800">4. Retention and Compliance</h3>
+          <p class="mt-3">Your data is used for account operations, service quality, moderation, and security monitoring, and may be retained for a reasonable period to meet legal, operational, or dispute-handling needs.</p>
+          <h3 class="mt-4 text-lg font-semibold text-slate-800">5. Your Acknowledgement</h3>
+          <p class="mt-3">By creating an account, you acknowledge and consent to this data use model and understand that reasonable safeguards, moderation checks, and policy enforcement are part of maintaining a secure campus marketplace.</p>
+          <p class="mt-3">You can request profile updates by editing account details, and we may retain limited records where required for legal obligations, fraud prevention, or dispute resolution.</p>
+        </div>
       `,
     },
   };

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -13,3 +13,83 @@ document.addEventListener("DOMContentLoaded", () => {
     }, 500);
   }, 5000);
 });
+
+document.addEventListener("DOMContentLoaded", () => {
+  const termsCheckbox = document.getElementById("terms-accepted-checkbox");
+  const signupButton = document.getElementById("signup-submit-btn");
+  const legalOverlay = document.getElementById("legal-modal-overlay");
+  const legalTitle = document.getElementById("legal-modal-title");
+  const legalContent = document.getElementById("legal-modal-content");
+  const legalClose = document.getElementById("legal-modal-close");
+  const legalTriggers = document.querySelectorAll("[data-legal-trigger]");
+
+  if (!termsCheckbox || !signupButton) return;
+
+  const LEGAL_COPY = {
+    terms: {
+      title: "Terms of Service",
+      body: `
+        <p>SwanFlip is for UWA community members only. By creating an account, you agree to use the marketplace honestly and respectfully.</p>
+        <p>You must provide accurate listing details, including real item condition, clear pricing, and truthful descriptions.</p>
+        <p>Transactions should be arranged safely in public places. Users are responsible for verifying items before payment.</p>
+        <p>Illegal products, prohibited goods, scams, and abusive behavior are not allowed and may result in account suspension.</p>
+      `,
+    },
+    privacy: {
+      title: "Privacy Policy",
+      body: `
+        <p>We collect basic profile information (name, email) to create and secure your account.</p>
+        <p>Your data is used to provide login/session functionality, listing management, and user-to-user communication features.</p>
+        <p>We do not request unnecessary personal data for marketplace use.</p>
+        <p>By continuing, you acknowledge that your account activity may be used to maintain platform safety and service quality.</p>
+      `,
+    },
+  };
+
+  const updateSignupButtonState = () => {
+    const enabled = termsCheckbox.checked;
+    signupButton.disabled = !enabled;
+    signupButton.classList.toggle("opacity-50", !enabled);
+    signupButton.classList.toggle("cursor-not-allowed", !enabled);
+    signupButton.classList.toggle("hover:scale-105", enabled);
+    signupButton.classList.toggle("hover:bg-blue-900", enabled);
+  };
+
+  const closeLegalModal = () => {
+    if (!legalOverlay) return;
+    legalOverlay.classList.add("hidden");
+    legalOverlay.classList.remove("flex");
+  };
+
+  const openLegalModal = (kind) => {
+    if (!legalOverlay || !legalTitle || !legalContent) return;
+    const selected = LEGAL_COPY[kind] || LEGAL_COPY.terms;
+    legalTitle.textContent = selected.title;
+    legalContent.innerHTML = selected.body;
+    legalOverlay.classList.remove("hidden");
+    legalOverlay.classList.add("flex");
+  };
+
+  termsCheckbox.addEventListener("change", updateSignupButtonState);
+  updateSignupButtonState();
+
+  legalTriggers.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      openLegalModal(btn.dataset.legalTrigger);
+    });
+  });
+
+  if (legalClose) {
+    legalClose.addEventListener("click", closeLegalModal);
+  }
+
+  if (legalOverlay) {
+    legalOverlay.addEventListener("click", (event) => {
+      if (event.target === legalOverlay) closeLegalModal();
+    });
+  }
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") closeLegalModal();
+  });
+});

--- a/templates/signuppage.html
+++ b/templates/signuppage.html
@@ -61,6 +61,35 @@ block content %}
         required
       />
 
+      <div class="w-full max-w-sm rounded-lg border border-slate-300 bg-slate-50 p-3">
+        <div class="flex items-start gap-3">
+          <input
+            id="terms-accepted-checkbox"
+            type="checkbox"
+            name="terms_accepted"
+            class="mt-1 h-4 w-4 rounded border-gray-400 text-blue-800 focus:ring-blue-700"
+          />
+          <label for="terms-accepted-checkbox" class="text-sm leading-6 text-slate-700">
+            I agree to the
+            <button
+              type="button"
+              data-legal-trigger="terms"
+              class="font-semibold text-blue-800 underline hover:text-blue-900"
+            >
+              Terms of Service
+            </button>
+            and
+            <button
+              type="button"
+              data-legal-trigger="privacy"
+              class="font-semibold text-blue-800 underline hover:text-blue-900"
+            >
+              Privacy Policy
+            </button>.
+          </label>
+        </div>
+      </div>
+
       <p class="text-sm text-black">
         Already have an account?
         <a
@@ -73,11 +102,46 @@ block content %}
 
       <button
         type="submit"
+        id="signup-submit-btn"
+        disabled
         class="w-fit rounded-lg bg-[#3D3A9E] px-10 py-3 font-medium text-white transition-all hover:scale-105 hover:bg-blue-900"
       >
         Sign up
       </button>
     </form>
+  </div>
+</div>
+
+<div
+  id="legal-modal-overlay"
+  class="fixed inset-0 z-50 hidden items-center justify-center bg-black/40 px-4"
+>
+  <div class="w-full max-w-2xl rounded-xl bg-white p-6 shadow-2xl">
+    <div class="mb-4 flex items-start justify-between gap-4">
+      <h2 id="legal-modal-title" class="text-2xl font-bold text-slate-800">Terms of Service</h2>
+      <button
+        type="button"
+        id="legal-modal-close"
+        class="rounded-md px-2 py-1 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+        aria-label="Close legal modal"
+      >
+        X
+      </button>
+    </div>
+    <div id="legal-modal-content" class="max-h-[60vh] space-y-4 overflow-y-auto pr-1 text-sm leading-6 text-slate-700">
+      <p>
+        SwanFlip is a student marketplace for the UWA community. By using this platform, you agree to list items honestly and communicate respectfully.
+      </p>
+      <p>
+        Buyers and sellers are responsible for arranging safe meetups, checking item condition, and following Australian law and UWA policies.
+      </p>
+      <p>
+        Prohibited listings include illegal goods, dangerous items, and misleading or fraudulent posts.
+      </p>
+      <p>
+        Your account information is used to provide core marketplace features, account security, and transaction-related communication.
+      </p>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/templates/signuppage.html
+++ b/templates/signuppage.html
@@ -116,7 +116,7 @@ block content %}
   id="legal-modal-overlay"
   class="fixed inset-0 z-50 hidden items-center justify-center bg-black/40 px-4"
 >
-  <div class="w-full max-w-2xl rounded-xl bg-white p-6 shadow-2xl">
+  <div class="w-full max-w-5xl rounded-xl bg-white p-6 shadow-2xl">
     <div class="mb-4 flex items-start justify-between gap-4">
       <h2 id="legal-modal-title" class="text-2xl font-bold text-slate-800">Terms of Service</h2>
       <button
@@ -128,19 +128,38 @@ block content %}
         X
       </button>
     </div>
-    <div id="legal-modal-content" class="max-h-[60vh] space-y-4 overflow-y-auto pr-1 text-sm leading-6 text-slate-700">
-      <p>
-        SwanFlip is a student marketplace for the UWA community. By using this platform, you agree to list items honestly and communicate respectfully.
-      </p>
-      <p>
-        Buyers and sellers are responsible for arranging safe meetups, checking item condition, and following Australian law and UWA policies.
-      </p>
-      <p>
-        Prohibited listings include illegal goods, dangerous items, and misleading or fraudulent posts.
-      </p>
-      <p>
-        Your account information is used to provide core marketplace features, account security, and transaction-related communication.
-      </p>
+    <div id="legal-modal-content" class="max-h-[76vh] overflow-y-auto pr-1 text-base leading-7 text-slate-700">
+      <div class="rounded-lg border border-slate-200 bg-slate-50 p-4">
+        <p class="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-semibold text-blue-700">
+          Effective date: 1 January 2026
+        </p>
+        <h3 class="mt-3 text-lg font-semibold text-slate-800">1. Account Use and Eligibility</h3>
+        <p>
+          SwanFlip is a student marketplace intended for the UWA community, and by creating an account you agree to use the platform honestly, respectfully, and in good faith.
+        </p>
+        <h3 class="mt-4 text-lg font-semibold text-slate-800">2. Listing Accuracy and Conduct</h3>
+        <p class="mt-3">
+          You are responsible for ensuring that listings are accurate, including item condition, photos, availability, and pricing, and you must not post misleading, deceptive, or fraudulent content.
+        </p>
+        <h3 class="mt-4 text-lg font-semibold text-slate-800">3. Buyer and Seller Responsibilities</h3>
+        <p class="mt-3">
+          Buyers and sellers are responsible for communicating clearly, arranging safe public meetups where possible, and verifying items before completing transactions.
+        </p>
+        <h3 class="mt-4 text-lg font-semibold text-slate-800">4. Risk, Safety and Enforcement</h3>
+        <p class="mt-3">
+          SwanFlip does not guarantee product quality, seller reliability, or delivery outcomes, so users should apply reasonable caution when trading.
+        </p>
+        <p class="mt-3">
+          Prohibited activity includes illegal or unsafe goods, impersonation, harassment, spam, payment scams, or conduct that violates Australian law or UWA policies.
+        </p>
+        <p class="mt-3">
+          We may remove listings, restrict account access, or suspend users who breach rules or create safety risks. By continuing, you acknowledge marketplace interactions are user-to-user transactions and agree to moderation and safety processes that help maintain a trusted campus marketplace.
+        </p>
+        <h3 class="mt-4 text-lg font-semibold text-slate-800">5. Policy Updates</h3>
+        <p class="mt-3">
+          If terms are updated, the latest version will be displayed at signup, and continued use of your account means you accept the revised terms unless local law requires additional consent.
+        </p>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Implemented Terms and Privacy consent flow on the Sign Up page. Added an agreement checkbox with clickable Terms of Service and Privacy Policy links,  and disabled Sign Up button until consent is checked. Added backend enforcement to reject signup submissions when terms are not accepted. Updated legal modal content to a wider, more readable format with section headings, paragraph-by-paragraph structure, and styled effective-date badges for both Terms and Privacy views

<img width="893" height="407" alt="image" src="https://github.com/user-attachments/assets/4829913b-f7e8-4828-9f75-cd30a4368892" />

--- 

<img width="862" height="353" alt="image" src="https://github.com/user-attachments/assets/d417a66e-3498-4899-a285-7bbf855172d7" />


closes #88 